### PR TITLE
Temporary Fix on webpack.config.js and SVG fix for bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Webpack 2 - Loading Bootstrap SCSS and JavaScript
 
-Webpack 2 with with Twitter Bootstrap CSS/SCSS and JavaScript.
+Learn how to setup Webpack 2 to load Twitter Bootstrap CSS/SCSS and JavaScript.
+
+## Webpack 2 Playlist
+
+[Watch on YouTube](https://www.youtube.com/watch?v=JdGnYNtuEtE&list=PLkEZWD8wbltnRp6nRR8kv97RbpcUdNawY)
 
 ## How to use the files?
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,6 @@
 # Webpack 2 - Loading Bootstrap SCSS and JavaScript
 
-Learn how to setup Webpack 2 to load Twitter Bootstrap CSS/SCSS and JavaScript.
-
-## Webpack 2 Playlist
-
-[Watch on YouTube](https://www.youtube.com/watch?v=JdGnYNtuEtE&list=PLkEZWD8wbltnRp6nRR8kv97RbpcUdNawY)
+Webpack 2 with with Twitter Bootstrap CSS/SCSS and JavaScript.
 
 ## How to use the files?
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -40,12 +40,15 @@ module.exports = {
             {
                 test: /\.(jpe?g|png|gif|svg)$/i,
                 use: [
-                    'file-loader?name=images/[name].[ext]',
-                    //'file-loader?name=[name].[ext]&outputPath=images/&publicPath=images/',
-                    'image-webpack-loader'
-                ]
-            },
-            { test: /\.(woff2?|svg)$/, loader: 'url-loader?limit=10000&name=fonts/[name].[ext]' },
+            'file-loader?name=image/[name].[ext]',
+            //'file-loader?name=[name].[ext]&outputPath=images/&publicPath=images/',
+
+        {
+          loader: 'image-webpack-loader',
+          options: {}
+        }]
+      },
+            { test: /\.(woff2?)$/, loader: 'url-loader?limit=10000&name=fonts/[name].[ext]' },
             { test: /\.(ttf|eot)$/, loader: 'file-loader?name=fonts/[name].[ext]' },
             // Bootstrap 3
             { test:/bootstrap-sass[\/\\]assets[\/\\]javascripts[\/\\]/, loader: 'imports-loader?jQuery=jquery' }


### PR DESCRIPTION
1. -To avoid this error when doing npm run dev:
Module build failed: TypeError: Cannot read property 'bypassOnDebug' of null
Caused by an issue on image-webpack-loader: https://github.com/tcoopman/image-webpack-loader/pull/87

2- To avoid svg error

Comment: Maybe you should change line 71 from 

            filename: '/css/[name].css',
to 
            filename: 'css/[name].css',
But im not quite sure.